### PR TITLE
Fix Capybara errors on Ruby 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: ruby
-before_install: gem install bundler:2.0.1
+rvm:
+  - 2.7
+  - 3.0
+  - 3.1
+script: bundle exec rake spec

--- a/lib/mache/dsl.rb
+++ b/lib/mache/dsl.rb
@@ -65,7 +65,7 @@ module Mache
       # @param options [Hash] a hash of options to pass to the Capybara finder
       def element(name, selector, options = {})
         define_method(name.to_s) do
-          Node.new(node: @node.find(selector, options))
+          Node.new(node: @node.find(selector, **options))
         end
 
         define_helper_methods(name, selector)
@@ -80,7 +80,7 @@ module Mache
         options = {minimum: 1}.merge(options)
 
         define_method(name.to_s) do
-          @node.all(selector, options).map do |node|
+          @node.all(selector, **options).map do |node|
             Node.new(node: node)
           end
         end
@@ -100,7 +100,7 @@ module Mache
         end
 
         define_method(name.to_s) do
-          klass.new(node: @node.find(selector, options))
+          klass.new(node: @node.find(selector, **options))
         end
 
         define_helper_methods(name, selector)
@@ -120,7 +120,7 @@ module Mache
         options = {minimum: 1}.merge(options)
 
         define_method(name.to_s) do
-          @node.all(selector, options).map do |node|
+          @node.all(selector, **options).map do |node|
             klass.new(node: node)
           end
         end

--- a/lib/mache/node.rb
+++ b/lib/mache/node.rb
@@ -29,11 +29,21 @@ module Mache
     end
 
     # Forwards any Capybara API calls to the node object.
-    def method_missing(name, *args, &block)
-      if @node.respond_to?(name)
-        @node.send(name, *args, &block)
-      else
-        super
+    if RUBY_VERSION < "3"
+      def method_missing(name, *args, &block)
+        if @node.respond_to?(name)
+          @node.send(name, *args, &block)
+        else
+          super
+        end
+      end
+    else
+      def method_missing(name, *args, **kwargs, &block)
+        if @node.respond_to?(name)
+          @node.send(name, *args, **kwargs, &block)
+        else
+          super
+        end
       end
     end
 

--- a/mache.gemspec
+++ b/mache.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capybara', '~> 3'
 
-  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'rack', '~> 2.0.7'
   spec.add_development_dependency 'rspec', '~> 3.8.0'

--- a/mache.gemspec
+++ b/mache.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files --exclude-standard -z -- lib/* CHANGELOG.md LICENSE.md README.md`.split("\x0")
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.7'
+
   spec.add_dependency 'capybara', '~> 3'
 
   spec.add_development_dependency 'rake', '~> 12.3.2'


### PR DESCRIPTION
Changes to keyword arguments in Ruby 3 mean an array of empty options can be passed to selectors, causing errors like:

```
ArgumentError:
  Unused parameters passed to Capybara::Queries::SelectorQuery : [{}]
```

See:
* https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
* https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html
* https://buildkite.com/conversation/tc/builds/90355#d254b93b-67e5-40b1-8b71-a04fdae3a82f